### PR TITLE
stop writing writing header to one-column list

### DIFF
--- a/wikipedia_views/scripts/fetch_daily_views.py
+++ b/wikipedia_views/scripts/fetch_daily_views.py
@@ -79,7 +79,6 @@ def main():
     t_Out = f"{outputPath}dailyviews{queryDate}.tsv"
 
     with open(articleFile, 'r') as infile:
-        next(infile) #skip header
         articleList = list(infile)
 
     j = []

--- a/wikipedia_views/scripts/wikiproject_scraper.py
+++ b/wikipedia_views/scripts/wikiproject_scraper.py
@@ -109,7 +109,6 @@ def main():
     #3 Saves the list to a file
 
     with open(outputFile, 'w') as f:
-        f.write("Article\n")
         f.write('\n'.join(articleNames)+'\n')
     logging.debug(f"Finished scrape and made a new article file at {datetime.datetime.now()}")
 


### PR DESCRIPTION
This feels like it's asking for trouble. Description of the contents
of the list is in the filename.